### PR TITLE
Turn on `exactOptionalPropertyTypes`.

### DIFF
--- a/src/Client/Pagination.ts
+++ b/src/Client/Pagination.ts
@@ -20,8 +20,8 @@ export const StringPaginationToken = Type.Unsafe<StringPaginationToken>(
 export interface ChunkPage<ChunkItem> {
   getNextPage(): Promise<ActionResult<ChunkPage<ChunkItem>, PaginationError>>;
   chunk: ChunkItem[];
-  nextToken?: StringPaginationToken;
-  previousToken?: StringPaginationToken;
+  nextToken: StringPaginationToken | undefined;
+  previousToken: StringPaginationToken | undefined;
   hasNext(): boolean;
   hasPrevious(): boolean;
   isFirstPage(): boolean;
@@ -29,9 +29,9 @@ export interface ChunkPage<ChunkItem> {
 
 export interface PaginationOptions {
   direction?: 'forwards' | 'backwards';
-  from?: StringPaginationToken;
-  itemLimitPerPage?: number;
-  to?: StringPaginationToken;
+  from?: StringPaginationToken | undefined;
+  itemLimitPerPage?: number | undefined;
+  to?: StringPaginationToken | undefined;
 }
 
 export type StreamPaginationForEachCB<ChunkItem> = (item: ChunkItem) => void;
@@ -90,8 +90,8 @@ export type StandardChunkPageGetter<ChunkItem> = (
 ) => Promise<ActionResult<PaginatedResponse<ChunkItem>, PaginationError>>;
 
 export class StandardChunkPage<ChunkItem> implements ChunkPage<ChunkItem> {
-  public readonly nextToken?: StringPaginationToken;
-  public readonly previousToken?: StringPaginationToken | undefined;
+  public readonly nextToken: StringPaginationToken | undefined;
+  public readonly previousToken: StringPaginationToken | undefined;
   readonly #isFirstPage: boolean;
   public static createFirstPage<ChunkItem>(
     chunkGetter: StandardChunkPageGetter<ChunkItem>,
@@ -115,8 +115,8 @@ export class StandardChunkPage<ChunkItem> implements ChunkPage<ChunkItem> {
       nextToken,
       previousToken,
     }: {
-      nextToken?: StringPaginationToken;
-      previousToken?: StringPaginationToken;
+      nextToken?: StringPaginationToken | undefined;
+      previousToken?: StringPaginationToken | undefined;
     },
     private readonly paginationOptions: Omit<
       StreamPaginationOptions<ChunkItem>,

--- a/src/Interface/Value.ts
+++ b/src/Interface/Value.ts
@@ -27,7 +27,9 @@ export class DecodeException extends ActionException {
     public readonly errors: ValueError[],
     suppressLog?: boolean
   ) {
-    super(ActionExceptionKind.Unknown, exception, message, { suppressLog });
+    super(ActionExceptionKind.Unknown, exception, message, {
+      suppressLog: suppressLog ?? false,
+    });
     if (!suppressLog) {
       DecodeException.log.error(this.uuid, ...this.errors);
     }

--- a/src/PolicyList/PolicyListRevision.ts
+++ b/src/PolicyList/PolicyListRevision.ts
@@ -105,7 +105,7 @@ export interface PolicyRoomRevision extends PolicyListRevision {
   /**
    * A shortcode that Mjolnir has associated wit the room.
    */
-  readonly shortcode?: string;
+  readonly shortcode: string | undefined;
   reviseFromChanges(changes: PolicyRuleChange[]): PolicyRoomRevision;
   /**
    * Create a new revision from the state of the associated Matrix room.

--- a/src/PolicyList/PolicyRuleEventBuilder.ts
+++ b/src/PolicyList/PolicyRuleEventBuilder.ts
@@ -20,11 +20,11 @@ export type PolicyRuleEventDescription = {
 };
 
 export type DescribeBuildPolicyEvent = {
-  state_key?: string;
-  type?: (typeof ALL_RULE_TYPES)[number];
-  content?: UnredactedPolicyContent;
-  copyFrom?: PolicyRuleEvent;
-  remove?: PolicyRuleEvent;
+  state_key?: string | undefined;
+  type?: (typeof ALL_RULE_TYPES)[number] | undefined;
+  content?: UnredactedPolicyContent | undefined;
+  copyFrom?: PolicyRuleEvent | undefined;
+  remove?: PolicyRuleEvent | undefined;
 };
 
 export function policyStateKeyFromContent(

--- a/src/Protection/ProtectedRoomsSet.ts
+++ b/src/Protection/ProtectedRoomsSet.ts
@@ -183,8 +183,8 @@ export class StandardProtectedRoomsSet implements ProtectedRoomsSet {
     for (const protection of this.protections.allProtections) {
       const permissionsChange =
         PowerLevelsMirror.calculateNewMissingPermissions(this.userID, {
-          nextPowerLevelsContent: nextPowerLevels,
-          previousPowerLevelsContent: previousPowerLevels,
+          nextPowerLevelsContent: nextPowerLevels ?? {},
+          previousPowerLevelsContent: previousPowerLevels ?? {},
           requiredEventPermissions: protection.requiredEventPermissions,
           requiredPermissions: protection.requiredPermissions,
           requiredStatePermissions: protection.requiredStatePermissions,

--- a/src/Protection/ProtectionsConfig/StandardProtectionsConfig.ts
+++ b/src/Protection/ProtectionsConfig/StandardProtectionsConfig.ts
@@ -31,7 +31,9 @@ async function loadProtecitons(
   {
     migrationHandler,
   }: {
-    migrationHandler?: SchemedDataManager<MjolnirEnabledProtectionsEvent>;
+    migrationHandler?:
+      | SchemedDataManager<MjolnirEnabledProtectionsEvent>
+      | undefined;
   }
 ): Promise<ActionResult<ProtectionsInfo>> {
   const storeResult = await store.requestAccountData();

--- a/src/SafeMatrixEvents/SafeMembershipEvent.ts
+++ b/src/SafeMatrixEvents/SafeMembershipEvent.ts
@@ -56,9 +56,11 @@ export const SafeMembershipEventMirror = Object.freeze({
     return {
       ...content,
       ...{
-        [UnsafeContentKey]: unsafeContent,
         [SafeMembershipEventContentKey]: true,
       },
+      ...(unsafeContent === undefined
+        ? {}
+        : { [UnsafeContentKey]: unsafeContent }),
     };
   },
   /**

--- a/src/StateTracking/DeclareRoomState.ts
+++ b/src/StateTracking/DeclareRoomState.ts
@@ -314,9 +314,9 @@ export function describePolicyRule({
 
 export type DescribeStateEventOptions = {
   sender: StringUserID;
-  state_key?: string;
-  content?: Record<string, unknown>;
-  room_id?: StringRoomID;
+  state_key?: string | undefined;
+  content?: Record<string, unknown> | undefined;
+  room_id?: StringRoomID | undefined;
   type: string;
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "declarationDir": "dist",
     "declarationMap": true,
+    "exactOptionalPropertyTypes": true,
     "outDir": "dist",
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
We're doing this because without it `Record` types with optional keys are downright dangerous and incorrect. 